### PR TITLE
Allow for custom scoring classes

### DIFF
--- a/hypopt/model_selection.py
+++ b/hypopt/model_selection.py
@@ -123,7 +123,10 @@ def _run_thread_job(params):
                     model.predict(job_params["X_val"]),
                 )
         # You provided your own scoring function.
-        elif type(scoring) in [metrics.scorer._PredictScorer, metrics.scorer._ProbaScorer]:
+        # Or you provided your own scoring class
+        elif type(scoring) in [metrics.scorer._PredictScorer, metrics.scorer._ProbaScorer] \
+            or metrics.scorer._PredictScorer in type(scoring).__bases__ \
+            or metrics.scorer._ProbaScorer in type(scoring).__bases__:
             score = scoring(model, job_params["X_val"], job_params["y_val"])
         # You provided a string specifying the metric, e.g. 'accuracy'
         else:


### PR DESCRIPTION
I created a custom scoring class as per sklearn documentation. This is a class that implements the interface

```__call__(clf, X, y)```

different from a scoring function, implementing the interface

```custom_function(y_true, y_pred)```

In the model selection file, you check for class equality, but my custom class doesn't pass the check, even if it will work the same as a _PredictScorer. So I suggest you also check in the inheritance chain.