### PR TITLE
hypopt/model_selection.py: fix

### DIFF
--- a/hypopt/model_selection.py
+++ b/hypopt/model_selection.py
@@ -162,7 +162,7 @@ def _run_thread_job(model_params):  # pragma: no cover
         elif type(scoring) in [scorer._PredictScorer, scorer._ProbaScorer] \
             or scorer._PredictScorer in type(scoring).__bases__ \
             or scorer._ProbaScorer in type(scoring).__bases__:
-            score = scoring(model_clone, job_params["X_val"], job_params["y_val"])
+            score = scoring(model_clone, X_val, y_val)
         # You provided a string specifying the metric, e.g. 'accuracy'
         else:
             score = _compute_score(


### PR DESCRIPTION
`X_val` and `y_val` should be used directly instead of using (now undefined) `job_params`