### PR TITLE
user-provided scorer can also be _ThresholdScorer

### DIFF
--- a/hypopt/model_selection.py
+++ b/hypopt/model_selection.py
@@ -159,10 +159,11 @@ def _run_thread_job(model_params):  # pragma: no cover
                     model_clone.predict(X_val),
                 )
         # Or you provided your own scoring class
-        elif type(scoring) in [scorer._PredictScorer, scorer._ProbaScorer] \
+        elif type(scoring) in [scorer._ThresholdScorer, scorer._PredictScorer, scorer._ProbaScorer] \
             or scorer._PredictScorer in type(scoring).__bases__ \
-            or scorer._ProbaScorer in type(scoring).__bases__:
-            score = scoring(model_clone, job_params["X_val"], job_params["y_val"])
+            or scorer._ProbaScorer in type(scoring).__bases__ \
+            or scorer._ThresholdScorer in type(scoring).__bases__:
+            score = scoring(model_clone, X_val, y_val)
         # You provided a string specifying the metric, e.g. 'accuracy'
         else:
             score = _compute_score(


### PR DESCRIPTION
I wanted to use a scorer made with `make_scorer(roc_auc_score, needs_threshold=True)`, which yields an instance of [_ThresholdScorer](https://github.com/scikit-learn/scikit-learn/blob/bbd64c16f403f6b1b982c95673324db84b1196e1/sklearn/metrics/_scorer.py#L316). This class was not supported so far, only _PredictScorer and _ProbaScorer. I don't see any reason why it shouldn't be. Also, there was no dict `job_params` (seems to be legacy), so I passed `X_val` and `y_val` directly to the scorer like e.g. in line 171.